### PR TITLE
feat: Shape out coin info modal

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "jest": "^29.3.1",
     "react": "^18.2.0",
     "react-breakpoints-hook": "^0.1.2",
+    "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^18.2.0",
     "react-icon": "^1.0.0",
     "react-icons": "^4.4.0",

--- a/frontend/src/components/CoinInfoModal.jsx
+++ b/frontend/src/components/CoinInfoModal.jsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import styles from './CoinInfoModal.module.scss';
-import IconAndCurrencyIdCell from './IconAndCurrencyIdCell';
+import { capitalize } from '../util/helpers';
 import { Markup } from 'interweave';
-import { convertSnakeCaseToStringRrepresentation } from '../util/helpers';
+import { Link } from 'react-router-dom';
+import { Scrollbars } from 'react-custom-scrollbars';
 
 function CoinInfoModal({ onClose, row }) {
+  const homepage = useRef(null);
+  homepage.current = row.homepage.split(',')[0];
+  const icon = useRef(null);
+  icon.current = row.image_thumb;
+
   function handleBackdropClick(evt) {
     evt.stopPropagation();
     onClose();
@@ -17,38 +23,36 @@ function CoinInfoModal({ onClose, row }) {
         onClick={(evt) => {
           evt.stopPropagation();
         }}>
-        <div className={styles.dialogContent}>
-          <div className={styles.dialogHeader}>
-            <IconAndCurrencyIdCell obj={row} />
+        {icon.current && (
+          <div className={styles.dialogContent}>
+            <div className={styles.dialogHeader}>
+              <img src={icon.current} alt="coin" />
+              <div className={styles.coinName}>
+                <h2>{capitalize(row.id)}</h2>
+              </div>
+              <div className={styles.coinSymbol}>
+                <p>{row.symbol.toUpperCase()}</p>
+              </div>
+            </div>
+            <div className={styles.dialogBody}>
+              <Scrollbars
+                renderView={(props) => <div {...props} className="scrollbarView" />}
+                autoHeight
+                autoHeightMin={300} // min-height and max-height must be set lower
+                autoHeightMax={400} // than the height of the dialogRoot
+              >
+                <p className={styles.coinDescription}>
+                  <Markup content={row.description}></Markup>
+                </p>
+              </Scrollbars>
+              <div className={styles.homepageLink}>
+                <Link to={homepage.current} target="_blank">
+                  {homepage.current}
+                </Link>
+              </div>
+            </div>
           </div>
-          <div className={styles.dialogBody}>
-            {['categories', 'homepage', 'blockchain_site', 'genesis_date', 'hashing_algorithm'].map(
-              (item) => (
-                <div className={styles.dialogPropertyPair}>
-                  <div>{convertSnakeCaseToStringRrepresentation(item)}</div>
-                  <div>{row[item] || '-'}</div>
-                </div>
-              )
-            )}
-            {[
-              'coingecko_score',
-              'developer_score',
-              'community_score',
-              'liquidity_score',
-              'public_interest_score',
-            ].map((score) => {
-              return (
-                <div className={styles.dialogPropertyPair}>
-                  <div>{convertSnakeCaseToStringRrepresentation(score)}</div>
-                  <div>{row[score]}</div>
-                </div>
-              );
-            })}
-            <p className={styles.coinDescription}>
-              <Markup content={row.description}></Markup>
-            </p>
-          </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/CoinInfoModal.jsx
+++ b/frontend/src/components/CoinInfoModal.jsx
@@ -1,15 +1,20 @@
 import React, { useRef } from 'react';
+import { Markup } from 'interweave';
+import { CgClose } from 'react-icons/cg';
+import { Link } from 'react-router-dom';
+
 import styles from './CoinInfoModal.module.scss';
 import { capitalize } from '../util/helpers';
-import { Markup } from 'interweave';
-import { Link } from 'react-router-dom';
 import { Scrollbars } from 'react-custom-scrollbars';
+import { useBreakpoints } from 'react-breakpoints-hook';
+import { BREAKPOINTS } from '../constants';
 
 function CoinInfoModal({ onClose, row }) {
   const homepage = useRef(null);
   homepage.current = row.homepage.split(',')[0];
   const icon = useRef(null);
   icon.current = row.image_thumb;
+  let { mobile } = useBreakpoints(BREAKPOINTS);
 
   function handleBackdropClick(evt) {
     evt.stopPropagation();
@@ -23,6 +28,7 @@ function CoinInfoModal({ onClose, row }) {
         onClick={(evt) => {
           evt.stopPropagation();
         }}>
+        {mobile && <CgClose onClick={handleBackdropClick}></CgClose>}
         {icon.current && (
           <div className={styles.dialogContent}>
             <div className={styles.dialogHeader}>

--- a/frontend/src/components/CoinInfoModal.module.scss
+++ b/frontend/src/components/CoinInfoModal.module.scss
@@ -14,11 +14,12 @@
   margin-right: auto;
   margin-top: 10rem;
   padding: 1rem 4rem;
-  overflow-y: auto;
   width: 50%;
-  height: 75%;
+  min-height: 500px;
+  max-height: 600px;
   background-color: $grey4;
   color: white;
+  border-radius: 12px;
 }
 
 .dialogContent {
@@ -28,29 +29,44 @@
 }
 
 .dialogHeader {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: [symbol] 3rem [name] 1fr;
+  grid-template-rows: [first-row] 3.8rem [second-row] 1.2rem;
+  align-items: center;
+  margin-bottom: 1rem;
 }
 
-/* Override the default styles for the IconAndCurrencyCell (p and img) */
-.dialogHeader p {
-  font-size: 24px;
+.coinName {
+  grid-column: name;
+  grid-row: first-row / second-row;
+}
+
+.coinSybmol {
+  grid-column: symbol;
+  grid-row: first-row / second-row;
 }
 
 .dialogHeader img {
-  margin-right: 1rem;
   height: 35px;
 }
 
-.dialogPropertyPair {
-  display: flex;
-  margin-top: 1rem;
+.dialogBody {
+  height: 70%;
+  margin: 0 auto;
 }
 
-.dialogPropertyPair > div:nth-child(1) {
-  margin-right: 1rem;
+.dialogBody > div {
+  margin-bottom: 2rem;
 }
 
 .coinDescription {
   color: #c2c2c2;
+}
+
+.homepageLink a {
+  text-decoration: underline;
+}
+
+.scrollbarView {
+  height: 20vh;
 }

--- a/frontend/src/components/CoinInfoModal.module.scss
+++ b/frontend/src/components/CoinInfoModal.module.scss
@@ -1,3 +1,4 @@
+@import '../breakpoints.scss';
 @import '../colors.scss';
 
 .backdrop {
@@ -22,10 +23,26 @@
   border-radius: 12px;
 }
 
+@media #{media-query(xs)}, #{media-query(ss)} {
+  .dialogRoot {
+    max-height: unset;
+    height: 100vh;
+    width: 100%;
+    margin-top: 0;
+    padding: 4rem 4rem;
+  }
+}
+
 .dialogContent {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+}
+
+@media #{media-query(xs)}, #{media-query(ss)} {
+  .dialogContent {
+    margin-top: 3rem;
+  }
 }
 
 .dialogHeader {

--- a/frontend/src/components/Prices.jsx
+++ b/frontend/src/components/Prices.jsx
@@ -8,25 +8,6 @@ import Table from './Table';
 import { renderCell, renderCellOverlay } from './CellOverlay';
 import CoinInfoModal from './CoinInfoModal';
 
-const COIN_INFO_PROPS = [
-  'id',
-  'name',
-  'symbol',
-  'image_thumb',
-  'categories',
-  'genesis_date',
-  'total_value_locked',
-  'homepage',
-  'blockchain_site',
-  'hashing_algorithm',
-  'coingecko_score',
-  'developer_score',
-  'community_score',
-  'liquidity_score',
-  'public_interest_score',
-  'description',
-];
-
 // TODO:
 // This url will be used to fetch data for all coins on the 1 Jan 2020, and
 // display the difference in %:
@@ -97,13 +78,9 @@ function Prices() {
     },
   ];
 
-  function handleRowClick(evt, row, cell) {
+  function handleRowClick(_, row) {
     setRow(row);
     setIsCoinInfoModalOpen(true);
-  }
-
-  function filterCoinInfoProps(obj) {
-    return Object.fromEntries(Object.entries(obj).filter(([key]) => COIN_INFO_PROPS.includes(key)));
   }
 
   return (
@@ -113,16 +90,16 @@ function Prices() {
           <CoinInfoModal
             isOpen={isCoinInfoModalOpen}
             onClose={() => setIsCoinInfoModalOpen(false)}
-            row={filterCoinInfoProps(row)}
+            row={row}
           />,
           document.body
         )}
       <Table
         tableData={tableData}
         coins={coins}
+        onRowClick={handleRowClick}
         rowStyles={styles}
         defaultOrderBy={['market_cap_rank']}
-        onRowClick={handleRowClick}
       />
     </>
   );

--- a/frontend/src/components/Table.jsx
+++ b/frontend/src/components/Table.jsx
@@ -8,13 +8,44 @@ import { BREAKPOINTS } from '../constants';
 import { objectSort } from '../util/helpers';
 import GroupingHeader from './GroupingHeader';
 
+function Card({ tableData, onCardClick, coin }) {
+  const location = useLocation();
+
+  let { mobile, tablet } = useBreakpoints(BREAKPOINTS);
+
+  return (
+    <div className={styles.cardContainer} onClick={(evt) => onCardClick(evt, coin, null)}>
+      <div className={styles.cardHeader}>
+        {tableData
+          .slice(0, 3) // The first 3 items go into the header
+          .map((item) => (
+            <div key={item.id} className={styles.cardHeaderCell}>
+              <span className={styles.cardHeaderCellLabel}>{item.label}</span>
+              <div className={styles.cardHeaderCellValue}>{item.render(coin)}</div>
+            </div>
+          ))}
+      </div>
+      <div>
+        {(mobile || tablet) && location.pathname === '/tokenomics' && <GroupingHeader />}
+        <div className={styles.cardBody}>
+          {tableData
+            .slice(3) // All the rest gos into the content area
+            .map((item) => (
+              <div key={item.id} className={styles.cardBodyCell}>
+                <span className={styles.cardBodyCellLabel}>{item.label}</span>
+                <div className={styles.cardBodyCellValue}>{item.render(coin)}</div>
+              </div>
+            ))}
+        </div>
+      </div>
+    </div>
+  );
+}
 function Table({ tableData, coins, rowStyles, defaultOrderBy, onRowClick }) {
   const [orderedCoins, setOrderedCoins] = useState(coins.order);
   const [order, setOrder] = useState('asc');
   const [orderBy, setOrderBy] = useState(defaultOrderBy);
-  const location = useLocation();
-
-  let { mobile, tablet, desktop } = useBreakpoints(BREAKPOINTS);
+  let { desktop } = useBreakpoints(BREAKPOINTS);
 
   function handleSort(_, cellId) {
     setOrder(order === 'asc' ? 'desc' : 'asc');
@@ -54,35 +85,12 @@ function Table({ tableData, coins, rowStyles, defaultOrderBy, onRowClick }) {
       ) : (
         <>
           {orderedCoins.map((coinGuid) => (
-            <div key={coinGuid} className={styles.cardContainer}>
-              <div className={styles.cardHeader}>
-                {tableData
-                  .slice(0, 3) // The first 3 items go into the header
-                  .map((item) => (
-                    <div key={item.id} className={styles.cardHeaderCell}>
-                      <span className={styles.cardHeaderCellLabel}>{item.label}</span>
-                      <div className={styles.cardHeaderCellValue}>
-                        {item.render(coins.data[coinGuid])}
-                      </div>
-                    </div>
-                  ))}
-              </div>
-              <div>
-                {(mobile || tablet) && location.pathname === '/tokenomics' && <GroupingHeader />}
-                <div className={styles.cardBody}>
-                  {tableData
-                    .slice(3) // All the rest gos into the content area
-                    .map((item) => (
-                      <div key={item.id} className={styles.cardBodyCell}>
-                        <span className={styles.cardBodyCellLabel}>{item.label}</span>
-                        <div className={styles.cardBodyCellValue}>
-                          {item.render(coins.data[coinGuid])}
-                        </div>
-                      </div>
-                    ))}
-                </div>
-              </div>
-            </div>
+            <Card
+              key={coinGuid}
+              tableData={tableData}
+              coin={coins.data[coinGuid]}
+              onCardClick={onRowClick}
+            />
           ))}
         </>
       )}

--- a/frontend/src/components/Tokenomics.jsx
+++ b/frontend/src/components/Tokenomics.jsx
@@ -1,5 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
+import { createPortal } from 'react-dom';
+
+import CoinInfoModal from './CoinInfoModal';
 import IconAndCurrencyIdCell from './IconAndCurrencyIdCell';
 import { formatLongNumbers } from '../util/helpers';
 import styles from './Tokenomics.module.scss';
@@ -10,6 +13,8 @@ import { BREAKPOINTS } from '../constants';
 function Tokenomics() {
   let { ss, mobile, tablet } = useBreakpoints(BREAKPOINTS);
   const { coins } = useOutletContext();
+  const [isCoinInfoModalOpen, setIsCoinInfoModalOpen] = useState(false);
+  const [row, setRow] = useState();
 
   const tableData = [
     {
@@ -76,14 +81,31 @@ function Tokenomics() {
     },
   ];
 
+  function handleRowClick(evt, row) {
+    setRow(row);
+    setIsCoinInfoModalOpen(true);
+  }
+
   return (
-    <Table
-      numberOfDynamicRows={4}
-      tableData={tableData}
-      coins={coins}
-      rowStyles={styles}
-      defaultOrderBy={['market_cap_rank']}
-    />
+    <>
+      {isCoinInfoModalOpen &&
+        createPortal(
+          <CoinInfoModal
+            isOpen={isCoinInfoModalOpen}
+            onClose={() => setIsCoinInfoModalOpen(false)}
+            row={row}
+          />,
+          document.body
+        )}
+      <Table
+        numberOfDynamicRows={4}
+        tableData={tableData}
+        coins={coins}
+        onRowClick={handleRowClick}
+        rowStyles={styles}
+        defaultOrderBy={['market_cap_rank']}
+      />
+    </>
   );
 }
 

--- a/frontend/src/util/helpers.js
+++ b/frontend/src/util/helpers.js
@@ -36,7 +36,7 @@ export function capitalize(string) {
   return `${string.slice(0, 1).toUpperCase()}${string.slice(1)}`;
 }
 
-export function convertSnakeCaseToStringRrepresentation(string) {
+export function convertSnakeCaseToStringRepresentation(string) {
   return string.split('_').reduce((acc, curr) => {
     acc += ` ${capitalize(curr)}`;
     return acc;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2597,6 +2597,11 @@ acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
+add-px-to-style@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/add-px-to-style/-/add-px-to-style-1.0.0.tgz#d0c135441fa8014a8137904531096f67f28f263a"
+  integrity sha512-YMyxSlXpPjD8uWekCQGuN40lV4bnZagUwqa2m/uFv1z/tNImSk9fnXVMUI5qwME/zzI3MMQRvjZ+69zyfSSyew==
+
 address@^1.0.1, address@^1.1.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/address/-/address-1.2.2.tgz#2b5248dac5485a6390532c6a517fda2e3faac89e"
@@ -3960,6 +3965,15 @@ dom-converter@^0.2.0:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-css@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/dom-css/-/dom-css-2.1.0.tgz#fdbc2d5a015d0a3e1872e11472bbd0e7b9e6a202"
+  integrity sha512-w9kU7FAbaSh3QKijL6n59ofAhkkmMJ31GclJIz/vyQdjogfyxcB6Zf8CZyibOERI5o0Hxz30VmJS7+7r5fEj2Q==
+  dependencies:
+    add-px-to-style "1.0.0"
+    prefix-style "2.0.1"
+    to-camel-case "1.0.0"
 
 dom-serializer@0:
   version "0.2.2"
@@ -7948,6 +7962,11 @@ postcss@^8.0.9, postcss@^8.3.5, postcss@^8.4.19, postcss@^8.4.4:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+prefix-style@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/prefix-style/-/prefix-style-2.0.1.tgz#66bba9a870cfda308a5dc20e85e9120932c95a06"
+  integrity sha512-gdr1MBNVT0drzTq95CbSNdsrBDoHGlb2aDJP/FoY+1e+jSDPOb1Cv554gH2MGiSr2WTcXi/zu+NaFzfcHQkfBQ==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -8019,7 +8038,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.5.10, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8078,7 +8097,7 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-raf@^3.4.1:
+raf@^3.1.0, raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -8125,6 +8144,15 @@ react-breakpoints-hook@^0.1.2:
   integrity sha512-WvcIURvKUnOlpJ0ezcAKaInrxtKNsBwqH343/p+4vlaoT5ALESmsgNGskhDDPtqyWR8cKqKnSmxVA/yw9zWUfg==
   dependencies:
     browser-monads "^1.0.0"
+
+react-custom-scrollbars@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/react-custom-scrollbars/-/react-custom-scrollbars-4.2.1.tgz#830fd9502927e97e8a78c2086813899b2a8b66db"
+  integrity sha512-VtJTUvZ7kPh/auZWIbBRceGPkE30XBYe+HktFxuMWBR2eVQQ+Ur6yFJMoaYcNpyGq22uYJ9Wx4UAEcC0K+LNPQ==
+  dependencies:
+    dom-css "^2.0.0"
+    prop-types "^15.5.10"
+    raf "^3.1.0"
 
 react-dev-utils@^12.0.1:
   version "12.0.1"
@@ -9222,10 +9250,22 @@ tmpl@1.0.5:
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
   integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
+to-camel-case@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-camel-case/-/to-camel-case-1.0.0.tgz#1a56054b2f9d696298ce66a60897322b6f423e46"
+  integrity sha512-nD8pQi5H34kyu1QDMFjzEIYqk0xa9Alt6ZfrdEMuHCFOfTLhDG5pgTu/aAM9Wt9lXILwlXmWP43b8sav0GNE8Q==
+  dependencies:
+    to-space-case "^1.0.0"
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
+
+to-no-case@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/to-no-case/-/to-no-case-1.0.2.tgz#c722907164ef6b178132c8e69930212d1b4aa16a"
+  integrity sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -9233,6 +9273,13 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+to-space-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-space-case/-/to-space-case-1.0.0.tgz#b052daafb1b2b29dc770cea0163e5ec0ebc9fc17"
+  integrity sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==
+  dependencies:
+    to-no-case "^1.0.0"
 
 toidentifier@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# Problem

The Coin Info dialog looks very unpolished. It can only be triggered from the Prices page

# Solution

- Enable the dialog from the Tokenomics page
- Enable and adapt the dialog to the tablet view
- Enable and adapt the dialog to the mobile view, show full screen
- Integrate the dialog with a decent looking scrollbar
- Remove obsolete code (stuff which was previously shown on the dialog)